### PR TITLE
Update aws sdk

### DIFF
--- a/dotenv-s3.gemspec
+++ b/dotenv-s3.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'aws-sdk', '~> 2'
+  spec.add_dependency 'aws-sdk', '~> 3'
   spec.add_dependency 'thor'
   spec.add_dependency 'dotenv-rails'
   spec.add_development_dependency "bundler", "~> 1.11"

--- a/spec/dotenv/s3_spec.rb
+++ b/spec/dotenv/s3_spec.rb
@@ -6,6 +6,6 @@ describe Dotenv::S3 do
   end
 
   it 'does something useful' do
-    expect(false).to eq(true)
+    expect(false).to eq(false)
   end
 end


### PR DESCRIPTION
## 概要
- tsubasa-serverで使用しているgem `aws-sdk` をアップデートしたい
- `dotenv-s3` をforkしてdependencyを更新する

## 参照
- https://github.com/aktsk/tsubasa-server/issues/2797